### PR TITLE
feat: add zed and opencode configuration support

### DIFF
--- a/cli/commands/backup.ts
+++ b/cli/commands/backup.ts
@@ -53,11 +53,31 @@ function getBashrcBackupItem(backupDir: string): BackupItem {
 	};
 }
 
+function getZedBackupItem(backupDir: string): BackupItem {
+	return {
+		source: join(homedir(), ".config", "zed", "settings.json"),
+		destination: join(backupDir, "zed", "settings.json"),
+		type: "file",
+		name: "zed",
+	};
+}
+
+function getOpencodeBackupItem(backupDir: string): BackupItem {
+	return {
+		source: join(homedir(), ".config", "opencode", "opencode.jsonc"),
+		destination: join(backupDir, "opencode", "opencode.jsonc"),
+		type: "file",
+		name: "opencode",
+	};
+}
+
 function getBackupItems(backupDir: string): BackupItem[] {
 	return [
 		getHelixBackupItem(backupDir),
 		getTmuxBackupItem(backupDir),
 		getBashrcBackupItem(backupDir),
+		getZedBackupItem(backupDir),
+		getOpencodeBackupItem(backupDir),
 	];
 }
 
@@ -259,6 +279,44 @@ backupCommand
 		mkdirSync(backupDir, { recursive: true });
 
 		const items = [getBashrcBackupItem(backupDir)];
+		const results = performBackup(items);
+		displayBackupResults(results, `backups/${dateStr}`);
+	});
+
+// Subcommand: backup zed
+backupCommand
+	.command("zed")
+	.description("Backup Zed configuration")
+	.action(() => {
+		console.log("Creating Zed backup...\n");
+
+		const today = new Date();
+		const dateStr = today.toISOString().split("T")[0];
+		const repoRoot = join(__dirname, "../..");
+		const backupDir = join(repoRoot, "backups", dateStr);
+
+		mkdirSync(backupDir, { recursive: true });
+
+		const items = [getZedBackupItem(backupDir)];
+		const results = performBackup(items);
+		displayBackupResults(results, `backups/${dateStr}`);
+	});
+
+// Subcommand: backup opencode
+backupCommand
+	.command("opencode")
+	.description("Backup opencode configuration")
+	.action(() => {
+		console.log("Creating opencode backup...\n");
+
+		const today = new Date();
+		const dateStr = today.toISOString().split("T")[0];
+		const repoRoot = join(__dirname, "../..");
+		const backupDir = join(repoRoot, "backups", dateStr);
+
+		mkdirSync(backupDir, { recursive: true });
+
+		const items = [getOpencodeBackupItem(backupDir)];
 		const results = performBackup(items);
 		displayBackupResults(results, `backups/${dateStr}`);
 	});

--- a/cli/commands/install.ts
+++ b/cli/commands/install.ts
@@ -8,6 +8,8 @@ import {
 	verifyBashrc,
 	verifyHelixConfig,
 	verifyTmuxConfig,
+	verifyZedConfig,
+	verifyOpencodeConfig,
 } from "./verify.ts";
 import { showConfigDiffs } from "../utils/show-config-diffs.ts";
 
@@ -221,6 +223,116 @@ function installBashrc(
 	}
 }
 
+function installZed(
+	dryrun = false,
+	force = false,
+	from?: string,
+): InstallResult {
+	try {
+		const repoRoot = join(__dirname, "../..");
+		const sourceBase = from
+			? join(repoRoot, "backups", from)
+			: join(repoRoot, "configs");
+		const source = join(sourceBase, "zed/settings.json");
+		const dest = join(homedir(), ".config", "zed", "settings.json");
+
+		if (!existsSync(source)) {
+			return {
+				name: "zed",
+				success: false,
+				message: from
+					? `backups/${from}/zed/settings.json not found`
+					: "configs/zed/settings.json not found in repo",
+			};
+		}
+
+		if (!force && existsSync(dest)) {
+			return {
+				name: "zed",
+				success: true,
+				skipped: true,
+				message:
+					"~/.config/zed/settings.json already exists (use --force to overwrite)",
+			};
+		}
+
+		if (!dryrun) {
+			const parentDir = dirname(dest);
+			if (!existsSync(parentDir)) {
+				mkdirSync(parentDir, { recursive: true });
+			}
+			copyFileSync(source, dest);
+		}
+
+		return {
+			name: "zed",
+			success: true,
+			message: dryrun ? `Would install: ${source} → ${dest}` : undefined,
+		};
+	} catch (error) {
+		return {
+			name: "zed",
+			success: false,
+			message: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+function installOpencode(
+	dryrun = false,
+	force = false,
+	from?: string,
+): InstallResult {
+	try {
+		const repoRoot = join(__dirname, "../..");
+		const sourceBase = from
+			? join(repoRoot, "backups", from)
+			: join(repoRoot, "configs");
+		const source = join(sourceBase, "opencode/opencode.jsonc");
+		const dest = join(homedir(), ".config", "opencode", "opencode.jsonc");
+
+		if (!existsSync(source)) {
+			return {
+				name: "opencode",
+				success: false,
+				message: from
+					? `backups/${from}/opencode/opencode.jsonc not found`
+					: "configs/opencode/opencode.jsonc not found in repo",
+			};
+		}
+
+		if (!force && existsSync(dest)) {
+			return {
+				name: "opencode",
+				success: true,
+				skipped: true,
+				message:
+					"~/.config/opencode/opencode.jsonc already exists (use --force to overwrite)",
+			};
+		}
+
+		if (!dryrun) {
+			const parentDir = dirname(dest);
+			if (!existsSync(parentDir)) {
+				mkdirSync(parentDir, { recursive: true });
+			}
+			copyFileSync(source, dest);
+		}
+
+		return {
+			name: "opencode",
+			success: true,
+			message: dryrun ? `Would install: ${source} → ${dest}` : undefined,
+		};
+	} catch (error) {
+		return {
+			name: "opencode",
+			success: false,
+			message: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
 function installAll(
 	dryrun = false,
 	force = false,
@@ -230,6 +342,8 @@ function installAll(
 		installHelix(dryrun, force, from),
 		installTmux(dryrun, force, from),
 		installBashrc(dryrun, force, from),
+		installZed(dryrun, force, from),
+		installOpencode(dryrun, force, from),
 	];
 }
 
@@ -246,6 +360,12 @@ function getVerifyResults(items: string[]): VerifyResult[] {
 				break;
 			case "bashrc":
 				results.push(verifyBashrc());
+				break;
+			case "zed":
+				results.push(verifyZedConfig());
+				break;
+			case "opencode":
+				results.push(verifyOpencodeConfig());
 				break;
 		}
 	}
@@ -496,6 +616,78 @@ installCommand
 		);
 		displayResults({
 			results: [installBashrc(dryrun, force, from)],
+			dryrun,
+			verify,
+			showDiff,
+		});
+	});
+
+// Subcommand: install zed
+installCommand
+	.command("zed")
+	.description("Install Zed configuration")
+	.option(
+		"-d, --dryrun",
+		"Show what would be installed without actually installing",
+	)
+	.option("-f, --force", "Force overwrite existing files")
+	.option("--no-verify", "Skip verification after installation")
+	.option("--diff", "Show differences before installation")
+	.option(
+		"--from <backup>",
+		"Install from a specific backup (e.g., 2024-01-15)",
+	)
+	.action((...args) => {
+		const cmd = args[args.length - 1];
+		const options = cmd.opts();
+		const parentOptions = cmd.parent?.opts() || {};
+		const dryrun = options.dryrun || parentOptions.dryrun || false;
+		const force = options.force || parentOptions.force || false;
+		const verify = options.verify !== false && parentOptions.verify !== false;
+		const showDiff = options.diff || parentOptions.diff || false;
+		const from = options.from || parentOptions.from;
+		const sourceDesc = from ? `backup (${from})` : "repo";
+		console.log(
+			`Installing Zed configuration from ${sourceDesc} to system${dryrun ? " (dry run)" : ""}...\n`,
+		);
+		displayResults({
+			results: [installZed(dryrun, force, from)],
+			dryrun,
+			verify,
+			showDiff,
+		});
+	});
+
+// Subcommand: install opencode
+installCommand
+	.command("opencode")
+	.description("Install opencode configuration")
+	.option(
+		"-d, --dryrun",
+		"Show what would be installed without actually installing",
+	)
+	.option("-f, --force", "Force overwrite existing files")
+	.option("--no-verify", "Skip verification after installation")
+	.option("--diff", "Show differences before installation")
+	.option(
+		"--from <backup>",
+		"Install from a specific backup (e.g., 2024-01-15)",
+	)
+	.action((...args) => {
+		const cmd = args[args.length - 1];
+		const options = cmd.opts();
+		const parentOptions = cmd.parent?.opts() || {};
+		const dryrun = options.dryrun || parentOptions.dryrun || false;
+		const force = options.force || parentOptions.force || false;
+		const verify = options.verify !== false && parentOptions.verify !== false;
+		const showDiff = options.diff || parentOptions.diff || false;
+		const from = options.from || parentOptions.from;
+		const sourceDesc = from ? `backup (${from})` : "repo";
+		console.log(
+			`Installing opencode configuration from ${sourceDesc} to system${dryrun ? " (dry run)" : ""}...\n`,
+		);
+		displayResults({
+			results: [installOpencode(dryrun, force, from)],
 			dryrun,
 			verify,
 			showDiff,

--- a/cli/commands/sync.ts
+++ b/cli/commands/sync.ts
@@ -143,8 +143,80 @@ function syncBashrc(dryrun = false): SyncResult {
 	}
 }
 
+function syncZed(dryrun = false): SyncResult {
+	try {
+		const repoRoot = join(__dirname, "../..");
+		const source = join(homedir(), ".config", "zed", "settings.json");
+		const dest = join(repoRoot, "configs/zed/settings.json");
+
+		if (!existsSync(source)) {
+			return {
+				name: "zed",
+				success: false,
+				message: "~/.config/zed/settings.json not found",
+			};
+		}
+
+		if (!dryrun) {
+			const parentDir = dirname(dest);
+			if (!existsSync(parentDir)) {
+				mkdirSync(parentDir, { recursive: true });
+			}
+			copyFileSync(source, dest);
+		}
+
+		return {
+			name: "zed",
+			success: true,
+			message: dryrun ? `Would sync: ${source} → ${dest}` : undefined,
+		};
+	} catch (error) {
+		return {
+			name: "zed",
+			success: false,
+			message: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+function syncOpencode(dryrun = false): SyncResult {
+	try {
+		const repoRoot = join(__dirname, "../..");
+		const source = join(homedir(), ".config", "opencode", "opencode.jsonc");
+		const dest = join(repoRoot, "configs/opencode/opencode.jsonc");
+
+		if (!existsSync(source)) {
+			return {
+				name: "opencode",
+				success: false,
+				message: "~/.config/opencode/opencode.jsonc not found",
+			};
+		}
+
+		if (!dryrun) {
+			const parentDir = dirname(dest);
+			if (!existsSync(parentDir)) {
+				mkdirSync(parentDir, { recursive: true });
+			}
+			copyFileSync(source, dest);
+		}
+
+		return {
+			name: "opencode",
+			success: true,
+			message: dryrun ? `Would sync: ${source} → ${dest}` : undefined,
+		};
+	} catch (error) {
+		return {
+			name: "opencode",
+			success: false,
+			message: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
 function syncAll(dryrun = false): SyncResult[] {
-	return [syncHelix(dryrun), syncTmux(dryrun), syncBashrc(dryrun)];
+	return [syncHelix(dryrun), syncTmux(dryrun), syncBashrc(dryrun), syncZed(dryrun), syncOpencode(dryrun)];
 }
 
 interface DisplayResultsOptions {
@@ -255,4 +327,34 @@ syncCommand
 			`Syncing bashrc configuration from system to repo${dryrun ? " (dry run)" : ""}...\n`,
 		);
 		displayResults({ results: [syncBashrc(dryrun)], dryrun });
+	});
+
+// Subcommand: sync zed
+syncCommand
+	.command("zed")
+	.description("Sync Zed configuration")
+	.option("-d, --dryrun", "Show what would be synced without actually syncing")
+	.action((_, cmd) => {
+		const options = cmd.opts();
+		const parentOptions = cmd.parent?.opts() || {};
+		const dryrun = options.dryrun || parentOptions.dryrun || false;
+		console.log(
+			`Syncing Zed configuration from system to repo${dryrun ? " (dry run)" : ""}...\n`,
+		);
+		displayResults({ results: [syncZed(dryrun)], dryrun });
+	});
+
+// Subcommand: sync opencode
+syncCommand
+	.command("opencode")
+	.description("Sync opencode configuration")
+	.option("-d, --dryrun", "Show what would be synced without actually syncing")
+	.action((_, cmd) => {
+		const options = cmd.opts();
+		const parentOptions = cmd.parent?.opts() || {};
+		const dryrun = options.dryrun || parentOptions.dryrun || false;
+		console.log(
+			`Syncing opencode configuration from system to repo${dryrun ? " (dry run)" : ""}...\n`,
+		);
+		displayResults({ results: [syncOpencode(dryrun)], dryrun });
 	});

--- a/cli/commands/verify.ts
+++ b/cli/commands/verify.ts
@@ -123,6 +123,40 @@ function verifyBashrc(): VerifyResult {
 	}
 }
 
+function verifyZedConfig(): VerifyResult {
+	const zedConfigPath = join(homedir(), ".config", "zed", "settings.json");
+
+	if (!existsSync(zedConfigPath)) {
+		return {
+			name: "zed",
+			installed: false,
+			message: "~/.config/zed/settings.json not found",
+		};
+	}
+
+	return {
+		name: "zed",
+		installed: true,
+	};
+}
+
+function verifyOpencodeConfig(): VerifyResult {
+	const opencodePath = join(homedir(), ".config", "opencode", "opencode.jsonc");
+
+	if (!existsSync(opencodePath)) {
+		return {
+			name: "opencode",
+			installed: false,
+			message: "~/.config/opencode/opencode.jsonc not found",
+		};
+	}
+
+	return {
+		name: "opencode",
+		installed: true,
+	};
+}
+
 function verifyHelixConfig(): VerifyResult {
 	const helixConfigPath = join(homedir(), ".config", "helix");
 
@@ -193,6 +227,8 @@ function verifyAll(): VerifyResult[] {
 		verifyZoxide(),
 		verifyStarship(),
 		verifyBashrc(),
+		verifyZedConfig(),
+		verifyOpencodeConfig(),
 		verifyGh(),
 		verifyHtop(),
 	];
@@ -393,5 +429,23 @@ verifyCommand
 		displayResults({ results: [verifyHtop()] });
 	});
 
+// Subcommand: verify zed
+verifyCommand
+	.command("zed")
+	.description("Verify Zed configuration")
+	.action(() => {
+		console.log("Verifying Zed configuration...\n");
+		displayResults({ results: [verifyZedConfig()] });
+	});
+
+// Subcommand: verify opencode
+verifyCommand
+	.command("opencode")
+	.description("Verify opencode configuration")
+	.action(() => {
+		console.log("Verifying opencode configuration...\n");
+		displayResults({ results: [verifyOpencodeConfig()] });
+	});
+
 // Export verification functions for use in other commands
-export { verifyHelixConfig, verifyTmuxConfig, verifyBashrc };
+export { verifyHelixConfig, verifyTmuxConfig, verifyBashrc, verifyZedConfig, verifyOpencodeConfig };

--- a/cli/utils/show-config-diffs.ts
+++ b/cli/utils/show-config-diffs.ts
@@ -38,5 +38,23 @@ export function showConfigDiffs(): void {
 		allDiffs.push(tmuxDiff);
 	}
 
+	// Compare zed config
+	const zedDiff = compareFiles(
+		join(__dirname, "../../configs/zed/settings.json"),
+		join(homedir(), ".config", "zed", "settings.json"),
+	);
+	if (zedDiff) {
+		allDiffs.push(zedDiff);
+	}
+
+	// Compare opencode config
+	const opencodeDiff = compareFiles(
+		join(__dirname, "../../configs/opencode/opencode.jsonc"),
+		join(homedir(), ".config", "opencode", "opencode.jsonc"),
+	);
+	if (opencodeDiff) {
+		allDiffs.push(opencodeDiff);
+	}
+
 	displayDiff(allDiffs);
 }

--- a/configs/opencode/opencode.jsonc
+++ b/configs/opencode/opencode.jsonc
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@tarquinen/opencode-dcp@latest", "opencode-mem"],
+   "provider": {
+    "lmstudio": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "LM Studio (local)",
+      "options": {
+        "baseURL": "http://127.0.0.1:1234/v1"
+      },
+      "models": {
+        "mistralai/ministral-3-3b": {
+          "name": "mistralai/ministral-3-3b (local)"
+        }
+      }
+    }
+  }
+}

--- a/configs/zed/settings.json
+++ b/configs/zed/settings.json
@@ -9,9 +9,6 @@
 {
   "terminal": {
     "font_family": "FiraCode Nerd Font Mono",
-    "shell": {
-      "program": "/opt/homebrew/bin/bash",
-    },
   },
   "git_panel": {
     "dock": "left",

--- a/configs/zed/settings.json
+++ b/configs/zed/settings.json
@@ -1,0 +1,108 @@
+// Zed settings
+//
+// For information on how to configure Zed, see the Zed
+// documentation: https://zed.dev/docs/configuring-zed
+//
+// To see all of Zed's default settings without changing your
+// custom settings, run `zed: open default settings` from the
+// command palette (cmd-shift-p / ctrl-shift-p)
+{
+  "terminal": {
+    "font_family": "FiraCode Nerd Font Mono",
+    "shell": {
+      "program": "/opt/homebrew/bin/bash",
+    },
+  },
+  "git_panel": {
+    "dock": "left",
+  },
+  "outline_panel": {
+    "dock": "left",
+  },
+  "agent": {
+    "sidebar_side": "right",
+    "dock": "right",
+    "favorite_models": [],
+    "model_parameters": [],
+  },
+  "icon_theme": {
+    "mode": "light",
+    "light": "Catppuccin Latte",
+    "dark": "Catppuccin Latte",
+  },
+  "project_panel": {
+    "dock": "left",
+    "scrollbar": {
+      "show": "never",
+    },
+  },
+  "edit_predictions": {
+    "provider": "copilot",
+  },
+  "session": {
+    "trust_all_worktrees": true,
+  },
+  "agent_servers": {
+    "opencode": {
+      "type": "registry",
+    },
+    "github-copilot-cli": {
+      "type": "registry",
+    },
+  },
+  "ui_font_size": 18,
+  "buffer_font_size": 15,
+  "theme": {
+    "mode": "system",
+    "light": "GitHub Light",
+    "dark": "GitHub Dark",
+  },
+  "tab_size": 2,
+  "soft_wrap": "editor_width",
+  "ensure_final_newline_on_save": true,
+  "remove_trailing_whitespace_on_save": true,
+  "inlay_hints": {
+    "enabled": true,
+    "show_type_hints": true,
+    "show_parameter_hints": true,
+  },
+  "code_lens": "on",
+  "scrollbar": {
+    "show": "never",
+  },
+  "languages": {
+    "JavaScript": {
+      "format_on_save": "on",
+      "formatter": {
+        "language_server": {
+          "name": "biome",
+        },
+      },
+      "code_actions_on_format": {
+        "source.organizeImports.biome": true,
+      },
+    },
+    "TypeScript": {
+      "format_on_save": "on",
+      "formatter": {
+        "language_server": {
+          "name": "biome",
+        },
+      },
+      "code_actions_on_format": {
+        "source.organizeImports.biome": true,
+      },
+    },
+    "TSX": {
+      "format_on_save": "on",
+      "formatter": {
+        "language_server": {
+          "name": "biome",
+        },
+      },
+      "code_actions_on_format": {
+        "source.organizeImports.biome": true,
+      },
+    },
+  },
+}


### PR DESCRIPTION
Closes #40
Closes #41

## Changes

### New config files
- `configs/zed/settings.json` — Zed editor settings (layout, themes, formatters, agent servers)
- `configs/opencode/opencode.jsonc` — opencode plugin config (dcp + opencode-mem plugins, local LM Studio provider)

### New CLI commands
All four operations (verify/sync/install/backup) now support `zed` and `opencode` as targets:

```
dotfiles verify zed
dotfiles verify opencode

dotfiles sync zed
dotfiles sync opencode

dotfiles install zed
dotfiles install opencode

dotfiles backup zed
dotfiles backup opencode
```

Both targets are also included in the `all` subcommand and the default action for each command.